### PR TITLE
Update superusers to account for string immutability

### DIFF
--- a/lib/capistrano/ext/superusers.rb
+++ b/lib/capistrano/ext/superusers.rb
@@ -6,9 +6,7 @@ Capistrano::Configuration.class_eval do
     user_sudo   = fetch(:user_sudo,   "sudo -u #{owner} -i")
     ssh_forward = fetch(:ssh_forward, "setfacl -m #{owner}:rwx $(dirname $SSH_AUTH_SOCK) && setfacl -m #{owner}:rwx $SSH_AUTH_SOCK")
     shell       = fetch(:user_shell,  :default_shell)
-    
-    cmd.gsub! "\n", ""
 
-    run "#{ssh_forward} && #{user_sudo} #{shell} -c '#{cmd}'", options
+    run "#{ssh_forward} && #{user_sudo} #{shell} -c '#{cmd.gsub('\n', '')}'", options
   end
 end

--- a/lib/capistrano/ext/superusers/version.rb
+++ b/lib/capistrano/ext/superusers/version.rb
@@ -3,7 +3,7 @@ module Capistrano
     module Superusers
       module Version
         MAJOR = 0
-        MINOR = 3
+        MINOR = 4
         TINY = 0
         STRING= [MAJOR, MINOR, TINY].join('.')
       end


### PR DESCRIPTION
As applications are migrating to newer versions of ruby, we need to support string immutability.