### PR TITLE
Fix run command due to break line issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/capistrano-ext-superuser.gemspec
+++ b/capistrano-ext-superuser.gemspec
@@ -11,7 +11,9 @@ Gem::Specification.new do |spec|
   spec.summary = 'Extend out from capistrano deploy user stuff and bits'
   spec.description = 'Capistrano extension to run sensible userage'
   spec.license = 'Simplified BSD'
-  spec.files = `git ls-files -z`.split("\x0")
+
+  spec.files = `git ls-files -z -- ./* ':(exclude)spec/*'`.split("\x0")
+
   spec.require_paths = ['lib']
 
   spec.add_dependency 'capistrano', '>=2.11.0'

--- a/lib/capistrano/ext/superusers.rb
+++ b/lib/capistrano/ext/superusers.rb
@@ -1,12 +1,14 @@
-require 'capistrano'
+require 'capistrano/all'
+
 Capistrano::Configuration.class_eval do
-  def superuser cmd, options={}
+  def superuser(cmd, options={})
     owner       = fetch(:owner,       'nobody')
 
     user_sudo   = fetch(:user_sudo,   "sudo -u #{owner} -i")
     ssh_forward = fetch(:ssh_forward, "setfacl -m #{owner}:rwx $(dirname $SSH_AUTH_SOCK) && setfacl -m #{owner}:rwx $SSH_AUTH_SOCK")
     shell       = fetch(:user_shell,  :default_shell)
 
-    run "#{ssh_forward} && #{user_sudo} #{shell} -c '#{cmd.gsub('\n', '')}'", options
+    single_line_cmd = cmd.gsub("\n", '')
+    run("#{ssh_forward} && #{user_sudo} #{shell} -c '#{single_line_cmd}'", options)
   end
 end

--- a/lib/capistrano/ext/superusers/version.rb
+++ b/lib/capistrano/ext/superusers/version.rb
@@ -4,7 +4,7 @@ module Capistrano
       module Version
         MAJOR = 0
         MINOR = 4
-        TINY = 1
+        TINY = 2
         STRING= [MAJOR, MINOR, TINY].join('.')
       end
     end

--- a/spec/lib/capistrano/ext/superusers_spec.rb
+++ b/spec/lib/capistrano/ext/superusers_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+require 'capistrano/ext/superusers'
+
+RSpec.describe Capistrano::Configuration do
+  describe '.superuser' do
+    subject(:configuration) { described_class.new }
+    let(:options) { double :options }
+
+    it 'runs a single-line command as a superuser' do
+      expect(configuration).to receive(:run).with(
+        "setfacl -m nobody:rwx $(dirname $SSH_AUTH_SOCK) && setfacl -m nobody:rwx $SSH_AUTH_SOCK && sudo -u nobody -i default_shell -c 'foo-bar'",
+        options
+      )
+      configuration.superuser("foo-bar", options)
+    end
+
+    it 'runs a multi-line command as a superuser' do
+      expect(configuration).to receive(:run).with(
+        "setfacl -m nobody:rwx $(dirname $SSH_AUTH_SOCK) && setfacl -m nobody:rwx $SSH_AUTH_SOCK && sudo -u nobody -i default_shell -c 'foobar'",
+        options
+      )
+      configuration.superuser("foo\nbar", options)
+    end
+
+    context 'with an owner' do
+      before do
+        allow(configuration).to receive(:fetch).and_call_original
+        allow(configuration).to receive(:fetch).with(:owner, 'nobody').and_return('root')
+      end
+
+      it 'runs a command as a root' do
+        expect(configuration).to receive(:run).with(
+          "setfacl -m root:rwx $(dirname $SSH_AUTH_SOCK) && setfacl -m root:rwx $SSH_AUTH_SOCK && sudo -u root -i default_shell -c 'foo-bar'",
+          options
+        )
+        configuration.superuser("foo-bar", options)
+      end
+    end
+
+    context 'with an user_shell' do
+      before do
+        allow(configuration).to receive(:fetch).and_call_original
+        allow(configuration).to receive(:fetch).with(:user_shell,  :default_shell).and_return('bash')
+      end
+
+      it 'runs a command using bash' do
+        expect(configuration).to receive(:run).with(
+          "setfacl -m nobody:rwx $(dirname $SSH_AUTH_SOCK) && setfacl -m nobody:rwx $SSH_AUTH_SOCK && sudo -u nobody -i bash -c 'foo-bar'",
+          options
+        )
+        configuration.superuser("foo-bar", options)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+RSpec.configure do |config|
+end


### PR DESCRIPTION
This PR intends to fix a problem with a command to be executed by capistrano. Before this fix capistrano was raising:

```shell
/bin/bash: -c: line 0: syntax error near unexpected token `echo'
```

This happened because we were not removing `\n` properly from the command.

- [x] 🐛 Fix gsub call on run command due to `\n` char
- [x] ✅  Add specs