### PR TITLE
🐛  Fix capistrano load to make it compatible to 2.15.5

### DIFF
--- a/lib/capistrano/ext/superusers.rb
+++ b/lib/capistrano/ext/superusers.rb
@@ -1,4 +1,8 @@
-require 'capistrano/all'
+begin
+  require 'capistrano/all'
+rescue LoadError
+  require 'capistrano'
+end
 
 Capistrano::Configuration.class_eval do
   def superuser(cmd, options={})


### PR DESCRIPTION
the gem `capistrano-ext-superusers` load capistrano by `capistrano/all` but on fca we use an old version of capistrano that does not have that file.

This changes happened on capistrano between: v2.15.9 and v3.0.1